### PR TITLE
Ensure engine decorators are loaded before host application

### DIFF
--- a/lib/rails/decorators/engine.rb
+++ b/lib/rails/decorators/engine.rb
@@ -4,11 +4,7 @@ module Rails
       isolate_namespace Rails::Decorators
 
       config.before_initialize do |app|
-        engines = ObjectSpace
-                    .each_object(Class)
-                    .select { |klass| klass < ::Rails::Engine }
-                    .select { |klass| klass.name.present? }
-                    .select { |klass| klass != ::Rails::Application }
+        engines = Rails::Engine.subclasses
 
         loader = Decorator.loader(engines.map(&:root) + [Rails.root])
         app.config.to_prepare(&loader)


### PR DESCRIPTION
Engine decorators should load before the host app so use of super in the
host app makes sense.  The old code would return the application itself.
Using Enging.subclasses won't return the application and is easier to
understand.