### PR TITLE
Fix decorating namespaced classes with same name

### DIFF
--- a/lib/rails/decorators/decorator.rb
+++ b/lib/rails/decorators/decorator.rb
@@ -51,7 +51,8 @@ module Rails
             )
           end
 
-          decorator_name = "#{options[:with].to_s.camelize}#{target.to_s.demodulize}Decorator"
+          namespace = target.to_s.remove('::')
+          decorator_name = "#{options[:with].to_s.camelize}#{namespace}Decorator"
 
           if target.const_defined?(decorator_name)
             # We are probably reloading in Rails development env if this happens

--- a/test/lib/rails/decorators/decorate_test.rb
+++ b/test/lib/rails/decorators/decorate_test.rb
@@ -11,41 +11,59 @@ class DecorateTest < Minitest::Test
     end
   end
 
+  module Namespace
+    class TestClass < TestClass
+      def foo
+        'baz'
+      end
+    end
+  end
+
   class ChildClass < TestClass
   end
 
-  def test_decorate
-    decorate(TestClass, with: 'testing') do
-      class_methods do
-        def foo
-          "#{super}|baz"
-        end
-      end
-
-      decorated { attr_reader :test }
-
+  decorate(TestClass, with: 'testing') do
+    class_methods do
       def foo
         "#{super}|baz"
       end
     end
 
+    decorated { attr_reader :test }
+
+    def foo
+      "#{super}|baz"
+    end
+  end
+
+  decorate(ChildClass, with: 'testing') do
+    def baz
+      'decorated'
+    end
+  end
+
+  decorate(Namespace::TestClass, with: 'testing') do
+    def foo
+      'namespace decorated'
+    end
+  end
+
+  def test_decorate
     assert(TestClass.new.respond_to?(:test))
     assert_equal('bar|baz', TestClass.new.foo)
     assert_equal('bar|baz', TestClass.foo)
   end
 
   def test_subclass_decoration
-    decorate(ChildClass, with: 'testing') do
-      def baz
-        'decorated'
-      end
-    end
-
     assert_equal('decorated', ChildClass.new.baz)
   end
 
+  def test_decorating_within_a_namespace
+    assert_equal('namespace decorated', Namespace::TestClass.new.foo)
+  end
+
   def test_module_definition
-    decorate(TestClass, with: 'tests') {}
-    assert(TestClass.const_defined?(:TestsTestClassDecorator))
+    decorate(TestClass, with: 'more_tests') {}
+    assert(TestClass.const_defined?(:MoreTestsDecorateTestTestClassDecorator))
   end
 end


### PR DESCRIPTION
This is accomplished by using the full module path to generate the
module name for decoration.

Fixes #7